### PR TITLE
DEEP-7542: fix date format

### DIFF
--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -171,7 +171,7 @@ func (m *Marshaler) Marshal(r types.Report) (*spdx.Document2_2, error) {
 			DocumentNamespace:    getDocumentNamespace(r, m),
 			CreatorOrganizations: []string{CreatorOrganization},
 			CreatorTools:         []string{CreatorTool},
-			Created:              m.clock.Now().UTC().Format(time.RFC3339Nano),
+			Created:              m.clock.Now().UTC().Format(time.RFC3339),
 		},
 		Packages:      packages,
 		Relationships: relationShips,

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -28,7 +28,7 @@ const (
 )
 
 const (
-	CategoryPackageManager = "PACKAGE_MANAGER"
+	CategoryPackageManager = "PACKAGE-MANAGER"
 	RefTypePurl            = "purl"
 
 	PropertySchemaVersion = "SchemaVersion"


### PR DESCRIPTION
1. Reverting the enum change to use a hyphen since this is valid in the latest spdx report.
2. Update the date format