### PR TITLE
Include license info in spdx report

### DIFF
--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -46,8 +46,6 @@ const (
 
 	PropertySchemaVersion = "SchemaVersion"
 
-	NoAssertion = "NOASSERTION"
-
 	// Image properties
 	PropertySize       = "Size"
 	PropertyImageID    = "ImageID"
@@ -134,15 +132,11 @@ func NewMarshaler(version string, opts ...marshalOption) *Marshaler {
 // The function augmentSpdxData updates each package in packages key,
 // ensuring the spdx json is valid as per https://tools.spdx.org/app/validate/
 // The following keys are being updated
-//  1. licenseConcluded (incorrect delimiter and string value throws error)
-//  2. licenseDeclared (incorrect delimiter and string value throws error)
-//  3. copyrightText (throws a warning if the value is empty)
-//  4. downloadLocation (throws a warning if the value is empty)
+// - copyrightText (throws a warning if the value is empty)
 func augmentSpdxData(p *spdx.Package) {
-	p.PackageLicenseConcluded = NoAssertion
-	p.PackageLicenseDeclared = NoAssertion
-	p.PackageCopyrightText = NoAssertion
-	p.PackageDownloadLocation = NoAssertion
+	if p.PackageCopyrightText == "" {
+		p.PackageCopyrightText = noneField
+	}
 }
 
 func (m *Marshaler) Marshal(r types.Report) (*spdx.Document, error) {


### PR DESCRIPTION
## Description
- Removing logic to hardcode license fields since license strings support the official operators now. https://github.com/aquasecurity/trivy/issues/3267

## Related issues
- https://df-eng.atlassian.net/browse/DEEP-8623

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
