### PR TITLE
Add app filepath for spdx SBOM

### DIFF
--- a/pkg/fanal/analyzer/sbom/sbom.go
+++ b/pkg/fanal/analyzer/sbom/sbom.go
@@ -36,7 +36,7 @@ func (a sbomAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (
 		return nil, xerrors.Errorf("failed to detect SBOM format: %w", err)
 	}
 
-	bom, err := sbom.Decode(input.Content, format)
+	bom, err := sbom.Decode(input.Content, format, input.FilePath)
 	if err != nil {
 		return nil, xerrors.Errorf("SBOM decode error: %w", err)
 	}

--- a/pkg/fanal/artifact/sbom/sbom.go
+++ b/pkg/fanal/artifact/sbom/sbom.go
@@ -50,7 +50,7 @@ func (a Artifact) Inspect(_ context.Context) (types.ArtifactReference, error) {
 	}
 	log.Logger.Infof("Detected SBOM format: %s", format)
 
-	bom, err := sbom.Decode(f, format)
+	bom, err := sbom.Decode(f, format, a.filePath)
 	if err != nil {
 		return types.ArtifactReference{}, xerrors.Errorf("SBOM decode error: %w", err)
 	}

--- a/pkg/fanal/handler/unpackaged/unpackaged.go
+++ b/pkg/fanal/handler/unpackaged/unpackaged.go
@@ -62,7 +62,7 @@ func (h unpackagedHook) Handle(ctx context.Context, res *analyzer.AnalysisResult
 		}
 
 		// Parse the fetched SBOM
-		bom, err := sbom.Decode(bytes.NewReader(raw), format)
+		bom, err := sbom.Decode(bytes.NewReader(raw), format, filePath)
 		if err != nil {
 			return err
 		}

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -178,7 +178,7 @@ func decodeAttestCycloneDXJSONFormat(r io.ReadSeeker) (Format, bool) {
 	return FormatAttestCycloneDXJSON, true
 }
 
-func Decode(f io.Reader, format Format) (types.SBOM, error) {
+func Decode(f io.Reader, format Format, filePath string) (types.SBOM, error) {
 	var (
 		v       interface{}
 		bom     types.SBOM
@@ -209,10 +209,10 @@ func Decode(f io.Reader, format Format) (types.SBOM, error) {
 		}
 		decoder = json.NewDecoder(f)
 	case FormatSPDXJSON:
-		v = &spdx.SPDX{SBOM: &bom}
+		v = &spdx.SPDX{SBOM: &bom, FilePath: filePath}
 		decoder = json.NewDecoder(f)
 	case FormatSPDXTV:
-		v = &spdx.SPDX{SBOM: &bom}
+		v = &spdx.SPDX{SBOM: &bom, FilePath: filePath}
 		decoder = spdx.NewTVDecoder(f)
 
 	default:

--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -28,6 +28,7 @@ var (
 
 type SPDX struct {
 	*types.SBOM
+	FilePath string
 }
 
 func NewTVDecoder(r io.Reader) *TVDecoder {
@@ -186,6 +187,7 @@ func (s *SPDX) parsePackages(pkgs map[common.ElementID]*spdx.Package) error {
 			app, ok := apps[pkgType]
 			if !ok {
 				app.Type = pkgType
+				app.FilePath = s.FilePath
 			}
 			app.Libraries = append(app.Libraries, *pkg)
 			apps[pkgType] = app

--- a/pkg/sbom/spdx/unmarshal_test.go
+++ b/pkg/sbom/spdx/unmarshal_test.go
@@ -255,7 +255,7 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			v := &spdx.SPDX{SBOM: &types.SBOM{}}
+			v := &spdx.SPDX{SBOM: &types.SBOM{}, FilePath: tt.inputFile}
 			err = json.NewDecoder(f).Decode(v)
 			if tt.wantErr != "" {
 				require.Error(t, err)


### PR DESCRIPTION
Note: For packages fetched from spdx files (by SBOM analyzer), app.FilePath was not set and hence the target for those packages where empty